### PR TITLE
refactor: Implement Error trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 data-encoding = "2.3"
 mac_address = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
+thiserror = "2.0.10"
 
 [dev-dependencies]
 quickcheck = "1"


### PR DESCRIPTION
Implement trait std::error::Error for enums FlakeGenErr and flake FlakeErr.