### PR TITLE
docs: Update comment with correct bit shift

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -52,7 +52,7 @@ impl FlakeGen {
     }
 
     /// Perform the neccessary bit manipulations to transform
-    /// 0000 0000 aaaa aaaa (timestamp) << 16 * 8
+    /// 0000 0000 aaaa aaaa (timestamp) << 8 * 8
     /// 0000 0000 00bb bbbb (node) << 2 * 8
     /// 0000 0000 0000 00cc (seq)
     /// into                XOR


### PR DESCRIPTION
The doc comment said that we were shifting the timestamp 16 bytes (128 bits) to the left, which was not correct. We are only shifting it 8 bytes (64 bits) to the left.